### PR TITLE
Update boards.txt

### DIFF
--- a/MSF_XINPUT/Teensyduino Files that were edited/hardware/teensy/avr/boards.txt
+++ b/MSF_XINPUT/Teensyduino Files that were edited/hardware/teensy/avr/boards.txt
@@ -47,6 +47,9 @@ teensy31.menu.usb.rawhid.fake_serial=teensy_gateway
 teensy31.menu.usb.flightsim=Flight Sim Controls
 teensy31.menu.usb.flightsim.build.usbtype=USB_FLIGHTSIM
 teensy31.menu.usb.flightsim.fake_serial=teensy_gateway
+teensy31.menu.usb.xinput=[MSF] Shoryuken! (XINPUT DEVICE)
+teensy31.menu.usb.xinput.build.usbtype=USB_XINPUT
+teensy31.menu.usb.xinput.fake_serial=teensy_gateway
 teensy31.menu.usb.disable=No USB
 teensy31.menu.usb.disable.build.usbtype=USB_DISABLED
 #uncomment these if you want to try faster overclocking


### PR DESCRIPTION
Add menu item for xinput on 3.1 and 3.2 teensy

Confirmed that code compiles for both the Teensy and 3.1/3.2 platforms.