### PR TITLE
Fix USB class declaration

### DIFF
--- a/MSF_XINPUT/Teensyduino Files that were edited/hardware/teensy/avr/cores/teensy3/usb_inst.cpp
+++ b/MSF_XINPUT/Teensyduino Files that were edited/hardware/teensy/avr/cores/teensy3/usb_inst.cpp
@@ -73,7 +73,7 @@ usb_serial_class Serial;
 #endif
 
 #ifdef USB_XINPUT
-usb_xinput_class XInput;
+usb_xinput_class XInputUSB;
 usb_serial_class Serial;
 #endif
 


### PR DESCRIPTION
This was defined as "XInput" but it's used as "XInputUSB". It's referenced within the `XINPUT` class (send/receive) and as `extern` in the `usb_xinput` header. This fixes things so the names match, and also fixes issues related to naming your XINPUT object "XInput".

I'm not entirely sure why this still compiled with the wrong declaration. My best guess is that it was optimized away as the class is all inline anyways.